### PR TITLE
Check for added or removed outputs before setting temperature

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -35,10 +35,6 @@ func New() (*Display, error) {
 		return nil, fmt.Errorf("got a nil display")
 	}
 
-	// go func() {
-	// 	C.wl_display_dispatch(state.display)
-	// }()
-
 	return &Display{
 		state: state,
 	}, nil

--- a/display/display.go
+++ b/display/display.go
@@ -1,7 +1,5 @@
 package display
 
-// TODO figure out how to compile C files from different subfolders.
-
 /*
 #cgo CFLAGS: -I${SRCDIR}/../protocol
 #cgo LDFLAGS: -lwayland-client -lm
@@ -16,18 +14,13 @@ import (
 
 // Display is a wrapper around a Wayland display.
 type Display struct {
-	state *C.wl_gammarelay_state_t
+	state *C.wl_gammarelay_t
 }
 
 // NewDisplay connects to Wayland server and gets a hold of the display.
-//
-// TODO The current naive implementation does not have a way to free any of the
-// resources acquired.
 func New() (*Display, error) {
-	state := &C.wl_gammarelay_state_t{}
-
-	ret := C.wl_gammarelay_init(state)
-	if ret != 0 {
+	state := C.wl_gammarelay_init()
+	if state == nil {
 		panic("failed to initialize gammarelay")
 	}
 
@@ -82,4 +75,12 @@ func (d *Display) SetColor(p ColorParams) error {
 	}
 
 	return nil
+}
+
+func (d *Display) Close() {
+	if d.state == nil {
+		return
+	}
+
+	C.wl_gammarelay_destroy(d.state)
 }

--- a/display/display.go
+++ b/display/display.go
@@ -31,7 +31,7 @@ type setColorRequest struct {
 func New() (*Display, error) {
 	state := C.wl_gammarelay_init()
 	if state == nil {
-		panic("failed to initialize gammarelay")
+		return nil, fmt.Errorf("failed to connect to display")
 	}
 
 	if state.display == nil {

--- a/display/display.go
+++ b/display/display.go
@@ -35,9 +35,9 @@ func New() (*Display, error) {
 		return nil, fmt.Errorf("got a nil display")
 	}
 
-	go func() {
-		C.wl_display_dispatch(state.display)
-	}()
+	// go func() {
+	// 	C.wl_display_dispatch(state.display)
+	// }()
 
 	return &Display{
 		state: state,

--- a/display/wl-gammarelay.c
+++ b/display/wl-gammarelay.c
@@ -535,12 +535,6 @@ int wl_gammarelay_color_set(wl_gammarelay_t *state, color_setting_t setting) {
 		}
 	}
 
-	if (wl_display_flush(state->display) == -1) {
-		fprintf(stderr,
-			"failed to flush display\n");
-		return -1;
-	}
-
 	return 0;
 }
 

--- a/display/wl-gammarelay.c
+++ b/display/wl-gammarelay.c
@@ -545,13 +545,13 @@ int wl_gammarelay_color_set(wl_gammarelay_t *state, color_setting_t setting) {
 }
 
 wl_gammarelay_t *wl_gammarelay_init() {
-	wl_gammarelay_t *state = calloc(1, sizeof(struct output));
+	wl_gammarelay_t *state = calloc(1, sizeof(wl_gammarelay_t));
 
 	state->display = wl_display_connect(NULL);
 	if (state->display == NULL) {
 		free(state);
 		fprintf(stderr, "failed to create display\n");
-		return state;
+		return NULL;
 	}
 
 	state->display_fd = wl_display_get_fd(state->display);
@@ -619,9 +619,8 @@ void wl_gammarelay_destroy(wl_gammarelay_t *state) {
 
 	if (state->display) {
 		fprintf(stderr, "disconnect display\n");
-		// TODO figure out why this crashes after calling wl_display_get_fd.
-		/* wl_display_disconnect(state->display); */
-		/* state->display = NULL; */
+		wl_display_disconnect(state->display);
+		state->display = NULL;
 	}
 
 	fprintf(stderr, "free state\n");

--- a/display/wl-gammarelay.h
+++ b/display/wl-gammarelay.h
@@ -1,4 +1,5 @@
 #include <wayland-client.h>
+#include "wlr-gamma-control-unstable-v1-client-protocol.h"
 
 /* Color setting */
 typedef struct {
@@ -7,6 +8,14 @@ typedef struct {
 	float brightness;
 } color_setting_t;
 
-int wl_gammarelay_color_set(struct wl_display *display, color_setting_t setting);
+typedef struct {
+	struct wl_display *display;
 
-int wl_gammarelay_init(struct wl_display **p_display);
+	struct wl_list outputs;
+
+	struct zwlr_gamma_control_manager_v1 *gamma_control_manager;
+} wl_gammarelay_state_t;
+
+int wl_gammarelay_color_set(wl_gammarelay_state_t *state, color_setting_t setting);
+
+int wl_gammarelay_init(wl_gammarelay_state_t *state);

--- a/display/wl-gammarelay.h
+++ b/display/wl-gammarelay.h
@@ -9,13 +9,17 @@ typedef struct {
 } color_setting_t;
 
 typedef struct {
+	struct wl_registry *registry;
+
 	struct wl_display *display;
 
 	struct wl_list outputs;
 
 	struct zwlr_gamma_control_manager_v1 *gamma_control_manager;
-} wl_gammarelay_state_t;
+} wl_gammarelay_t;
 
-int wl_gammarelay_color_set(wl_gammarelay_state_t *state, color_setting_t setting);
+int wl_gammarelay_color_set(wl_gammarelay_t *state, color_setting_t setting);
 
-int wl_gammarelay_init(wl_gammarelay_state_t *state);
+wl_gammarelay_t *wl_gammarelay_init();
+
+void wl_gammarelay_destroy(wl_gammarelay_t *state);

--- a/display/wl-gammarelay.h
+++ b/display/wl-gammarelay.h
@@ -13,6 +13,10 @@ typedef struct {
 
 	struct wl_display *display;
 
+	int display_fd;
+
+	int num_init_outputs;
+
 	struct wl_list outputs;
 
 	struct zwlr_gamma_control_manager_v1 *gamma_control_manager;
@@ -20,6 +24,10 @@ typedef struct {
 
 int wl_gammarelay_color_set(wl_gammarelay_t *state, color_setting_t setting);
 
+int wl_gammarelay_poll(wl_gammarelay_t *state);
+
 wl_gammarelay_t *wl_gammarelay_init();
 
 void wl_gammarelay_destroy(wl_gammarelay_t *state);
+
+int wl_gammarelay_num_init_outputs(wl_gammarelay_t *state);

--- a/display/wl-gammarelay.h
+++ b/display/wl-gammarelay.h
@@ -15,6 +15,8 @@ typedef struct {
 
 	int display_fd;
 
+	int interrupt_fd;
+
 	int num_init_outputs;
 
 	struct wl_list outputs;
@@ -25,6 +27,8 @@ typedef struct {
 int wl_gammarelay_color_set(wl_gammarelay_t *state, color_setting_t setting);
 
 int wl_gammarelay_poll(wl_gammarelay_t *state);
+
+void wl_gammarelay_interrupt(wl_gammarelay_t *state);
 
 wl_gammarelay_t *wl_gammarelay_init();
 

--- a/service/service.go
+++ b/service/service.go
@@ -25,6 +25,7 @@ type Service struct {
 
 type Display interface {
 	SetColor(display.ColorParams) error
+	Close()
 }
 
 type Params struct {
@@ -55,6 +56,8 @@ func New(params Params) *Service {
 }
 
 func (s *Service) Close() error {
+	s.params.Display.Close()
+
 	return s.params.Listener.Close()
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -24,7 +24,7 @@ type Service struct {
 }
 
 type Display interface {
-	SetColor(display.ColorParams) error
+	SetColor(context.Context, display.ColorParams) error
 	Close()
 }
 
@@ -258,7 +258,7 @@ func (s *Service) handleRequest(ctx context.Context, rwr requestWithResponse) {
 			return
 		}
 
-		err = s.params.Display.SetColor(colorParams)
+		err = s.params.Display.SetColor(ctx, colorParams)
 		if err != nil {
 			log.Printf("Failed to set color: %s\n", err)
 


### PR DESCRIPTION
Hey @MaxVerevkin,

I think I have something working. The trick is to call `wl_display_roundtrip` to execute all pending events, then all the callbacks will be executed synchronously.

The current implementation will check for any new outputs on every call to `wl_gammarelay_color_set` and initialize the gamma for those.

Ideally this would happen automatically, but that requires some more careful considerations because we'd have to access the state from different threads and that could cause race conditions, so I'm not sure if I have time to implement it at this point.

Would be great if you could test and see if this works for you!

Cheers!

Closes #3.