### PR TITLE
Initialize display after connecting to DBus

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,11 +51,13 @@ func parseArgs(argsSlice []string) (Arguments, error) {
 func main() {
 	args, err := parseArgs(os.Args)
 	if err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
 	}
 
 	if err := main2(args); err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(2)
 	}
 }
 
@@ -100,12 +102,16 @@ func main2(args Arguments) error {
 
 	defer disp.Close()
 
-	conn, err := NewDBus(ctx, logger, disp)
+	conn, err := NewDBus(logger)
 	if err != nil {
 		return fmt.Errorf("failed to connect to dbus: %w", err)
 	}
 
 	defer conn.Close()
+
+	if err := conn.RegisterDisplayService(ctx, disp); err != nil {
+		return fmt.Errorf("failed to initialize display service")
+	}
 
 	<-ctx.Done()
 

--- a/main.go
+++ b/main.go
@@ -95,19 +95,19 @@ func main2(args Arguments) error {
 		return NewSubscriber(ctx, args.Subscribe)
 	}
 
-	disp, err := display.New(logger)
-	if err != nil {
-		return fmt.Errorf("failed to open display: %w", err)
-	}
-
-	defer disp.Close()
-
 	conn, err := NewDBus(logger)
 	if err != nil {
 		return fmt.Errorf("failed to connect to dbus: %w", err)
 	}
 
 	defer conn.Close()
+
+	disp, err := display.New(logger)
+	if err != nil {
+		return fmt.Errorf("failed to open display: %w", err)
+	}
+
+	defer disp.Close()
 
 	if err := conn.RegisterDisplayService(ctx, disp); err != nil {
 		return fmt.Errorf("failed to initialize display service")


### PR DESCRIPTION
This fixes a bug where the color temperature would be reset and the service would fail to start if there was already another service registered as a primary owner of the `rs.wl-gammarelay` service.

Closes #6